### PR TITLE
Add CGLError return to CGLDestroyPixelFormat

### DIFF
--- a/src/cgl.rs
+++ b/src/cgl.rs
@@ -119,7 +119,7 @@ extern {
                                   pix_num: GLint,
                                   attrib: CGLPixelFormatAttribute,
                                   value: *mut GLint) -> CGLError;
-    pub fn CGLDestroyPixelFormat(pix: CGLPixelFormatObj);
+    pub fn CGLDestroyPixelFormat(pix: CGLPixelFormatObj) -> CGLError;
 
     // Context functions
     pub fn CGLCreateContext(pix: CGLPixelFormatObj, share: CGLContextObj, ctx: *mut CGLContextObj) ->


### PR DESCRIPTION
According to the [reference](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/CGL_OpenGL/index.html#//apple_ref/c/func/CGLDestroyPixelFormat) this should be the return value.